### PR TITLE
feat: Create Activity service

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,10 +6,7 @@ import (
 )
 
 func main() {
-	activityService := activities.NewService()
-	activitiesHandler := activities.NewHandler(activityService)
 	r := gin.Default()
-	r.GET("/hello/:name", activities.HandleHello)
-	r.GET("/activities/:id", activitiesHandler.HandleReadActivity)
+	r = activities.SetupRouter(r)
 	r.Run() // Run and serve on 8080
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/amrllkmn/apex/internal/activities"
+	"github.com/gin-gonic/gin"
 )
 
 func main() {
+	activityService := activities.NewService()
+	activitiesHandler := activities.NewHandler(activityService)
 	r := gin.Default()
 	r.GET("/hello/:name", activities.HandleHello)
+	r.GET("/activities/:id", activitiesHandler.HandleReadActivity)
 	r.Run() // Run and serve on 8080
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,5 +8,5 @@ import (
 func main() {
 	r := gin.Default()
 	r = activities.SetupRouter(r)
-	r.Run() // Run and serve on 8080
+	r.Run(":8081") // Run and serve on 8080
 }

--- a/internal/activities/handler.go
+++ b/internal/activities/handler.go
@@ -64,3 +64,10 @@ func (handler *Handler) HandleCreateActivity(c *gin.Context) {
 		"activity": activity,
 	})
 }
+
+func (handler *Handler) HandleGetActivities(c *gin.Context) {
+	activities := handler.service.GetActivities()
+	c.JSON(http.StatusOK, gin.H{
+		"activities": activities,
+	})
+}

--- a/internal/activities/handler.go
+++ b/internal/activities/handler.go
@@ -105,7 +105,6 @@ func (handler *Handler) HandleUpdateActivity(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"message": activity,
 	})
-	return
 }
 
 func (handler *Handler) HandleDeleteActivity(c *gin.Context) {

--- a/internal/activities/handler.go
+++ b/internal/activities/handler.go
@@ -1,6 +1,7 @@
 package activities
 
 import (
+	"fmt"
 	"net/http"
 
 	"strconv"
@@ -69,5 +70,62 @@ func (handler *Handler) HandleGetActivities(c *gin.Context) {
 	activities := handler.service.GetActivities()
 	c.JSON(http.StatusOK, gin.H{
 		"activities": activities,
+	})
+}
+
+func (handler *Handler) HandleUpdateActivity(c *gin.Context) {
+	activity_id, convErr := strconv.Atoi(c.Param("id"))
+
+	if convErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "id is not a number",
+		})
+		return
+	}
+
+	body := Activity{}
+	bindErr := c.BindJSON(&body)
+
+	if bindErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": bindErr,
+		})
+		return
+	}
+
+	activity, svcErr := handler.service.UpdateActivity(activity_id, &body)
+	fmt.Println(activity)
+	if svcErr != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"message": "No activity with id" + c.Param("id"),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": activity,
+	})
+	return
+}
+
+func (handler *Handler) HandleDeleteActivity(c *gin.Context) {
+	activity_id, err := strconv.Atoi(c.Param("id"))
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "id is not a number",
+		})
+		return
+	}
+
+	activity, err := handler.service.DeleteActivity(activity_id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"message": "No activity with id" + c.Param("id"),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"message": activity,
 	})
 }

--- a/internal/activities/handler.go
+++ b/internal/activities/handler.go
@@ -39,3 +39,28 @@ func (handler *Handler) HandleReadActivity(c *gin.Context) {
 		"message": activity,
 	})
 }
+
+func (handler *Handler) HandleCreateActivity(c *gin.Context) {
+	body := Activity{}
+	err := c.BindJSON(&body)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": err,
+		})
+		return
+	}
+
+	activity, serviceError := handler.service.CreateActivity(&body)
+
+	if serviceError != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"message": serviceError,
+		})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"activity": activity,
+	})
+}

--- a/internal/activities/handler.go
+++ b/internal/activities/handler.go
@@ -18,14 +18,6 @@ func NewHandler(service ActivityService) *Handler {
 	}
 }
 
-func HandleHello(c *gin.Context) {
-	name := c.Param("name")
-	message := "Hello " + name
-	c.JSON(http.StatusOK, gin.H{
-		"message": message,
-	})
-}
-
 func (handler *Handler) HandleReadActivity(c *gin.Context) {
 	activity_id, error := strconv.Atoi(c.Param("id"))
 	if error != nil {

--- a/internal/activities/handler.go
+++ b/internal/activities/handler.go
@@ -3,13 +3,47 @@ package activities
 import (
 	"net/http"
 
+	"strconv"
+
 	"github.com/gin-gonic/gin"
 )
+
+type Handler struct {
+	service ActivityService
+}
+
+func NewHandler(service ActivityService) *Handler {
+	return &Handler{
+		service: service,
+	}
+}
 
 func HandleHello(c *gin.Context) {
 	name := c.Param("name")
 	message := "Hello " + name
 	c.JSON(http.StatusOK, gin.H{
 		"message": message,
+	})
+}
+
+func (handler *Handler) HandleReadActivity(c *gin.Context) {
+	activity_id, error := strconv.Atoi(c.Param("id"))
+	if error != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "id is not a number",
+		})
+		return
+	}
+
+	// call ActivityService
+	activity, err := handler.service.GetActivity(activity_id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"message": "No activity with id" + c.Param("id"),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"message": activity,
 	})
 }

--- a/internal/activities/router.go
+++ b/internal/activities/router.go
@@ -10,7 +10,7 @@ func SetupRouter(r *gin.Engine) *gin.Engine {
 	r.POST("v1/activities", activitiesHandler.HandleCreateActivity)
 	r.GET("v1/activities", activitiesHandler.HandleGetActivities)
 	r.GET("v1/activities/:id", activitiesHandler.HandleReadActivity)
-	r.PUT("/v1/activities/:id", activitiesHandler.HandleUpdateActivity)
+	r.PATCH("/v1/activities/:id", activitiesHandler.HandleUpdateActivity)
 	r.DELETE("/v1/activities/:id", activitiesHandler.HandleDeleteActivity)
 	return r
 }

--- a/internal/activities/router.go
+++ b/internal/activities/router.go
@@ -7,7 +7,8 @@ import (
 func SetupRouter(r *gin.Engine) *gin.Engine {
 	activityService := NewService()
 	activitiesHandler := NewHandler(activityService)
-	r.GET("v1/activities/:id", activitiesHandler.HandleReadActivity)
 	r.POST("v1/activities", activitiesHandler.HandleCreateActivity)
+	r.GET("v1/activities", activitiesHandler.HandleGetActivities)
+	r.GET("v1/activities/:id", activitiesHandler.HandleReadActivity)
 	return r
 }

--- a/internal/activities/router.go
+++ b/internal/activities/router.go
@@ -10,7 +10,7 @@ func SetupRouter(r *gin.Engine) *gin.Engine {
 	r.POST("v1/activities", activitiesHandler.HandleCreateActivity)
 	r.GET("v1/activities", activitiesHandler.HandleGetActivities)
 	r.GET("v1/activities/:id", activitiesHandler.HandleReadActivity)
-	r.PATCH("/v1/activities/:id", activitiesHandler.HandleUpdateActivity)
+	r.PUT("/v1/activities/:id", activitiesHandler.HandleUpdateActivity)
 	r.DELETE("/v1/activities/:id", activitiesHandler.HandleDeleteActivity)
 	return r
 }

--- a/internal/activities/router.go
+++ b/internal/activities/router.go
@@ -1,0 +1,12 @@
+package activities
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func SetupRouter(r *gin.Engine) *gin.Engine {
+	activityService := NewService()
+	activitiesHandler := NewHandler(activityService)
+	r.GET("v1/activities/:id", activitiesHandler.HandleReadActivity)
+	return r
+}

--- a/internal/activities/router.go
+++ b/internal/activities/router.go
@@ -8,5 +8,6 @@ func SetupRouter(r *gin.Engine) *gin.Engine {
 	activityService := NewService()
 	activitiesHandler := NewHandler(activityService)
 	r.GET("v1/activities/:id", activitiesHandler.HandleReadActivity)
+	r.POST("v1/activities", activitiesHandler.HandleCreateActivity)
 	return r
 }

--- a/internal/activities/router.go
+++ b/internal/activities/router.go
@@ -10,5 +10,7 @@ func SetupRouter(r *gin.Engine) *gin.Engine {
 	r.POST("v1/activities", activitiesHandler.HandleCreateActivity)
 	r.GET("v1/activities", activitiesHandler.HandleGetActivities)
 	r.GET("v1/activities/:id", activitiesHandler.HandleReadActivity)
+	r.PATCH("/v1/activities/:id", activitiesHandler.HandleUpdateActivity)
+	r.DELETE("/v1/activities/:id", activitiesHandler.HandleDeleteActivity)
 	return r
 }

--- a/internal/activities/service.go
+++ b/internal/activities/service.go
@@ -20,29 +20,39 @@ type ActivityService interface {
 	GetActivities() []Activity
 	GetActivity(id int) (string, error)
 	CreateActivity(activity *Activity) (string, error)
+	UpdateActivity(id int, activity *Activity) (string, error)
+	DeleteActivity(id int) (string, error)
 }
-
-// the Service struct
-type Service struct{}
 
 // Take data from handler and call create an Activity
-// Take data from handler and call read an Activity
-func (svc *Service) GetActivity(id int) (string, error) {
-	return "Got activity", nil
-}
-
 func (svc *Service) CreateActivity(activity *Activity) (string, error) {
 	fmt.Println(*activity)
 	return "Created activity", nil
+}
+
+// Take data from handler and call read an Activity
+func (svc *Service) GetActivity(id int) (string, error) {
+	return "Got activity", nil
 }
 
 func (svc *Service) GetActivities() []Activity {
 	return []Activity{}
 }
 
+// Take data from handler and call update an Activity
+func (svc *Service) UpdateActivity(id int, activity *Activity) (string, error) {
+	fmt.Println(*activity)
+	return "Updated activity", nil
+}
+
+// Take data from handler and call delete an Activity
+func (svc *Service) DeleteActivity(id int) (string, error) {
+	return "Deleted activity", nil
+}
+
+// the Service struct
+type Service struct{}
+
 func NewService() ActivityService {
 	return &Service{}
 }
-
-// Take data from handler and call update an Activity
-// Take data from handler and call delete an Activity

--- a/internal/activities/service.go
+++ b/internal/activities/service.go
@@ -17,6 +17,7 @@ type Activity struct {
 
 // the Activity Service interface
 type ActivityService interface {
+	GetActivities() []Activity
 	GetActivity(id int) (string, error)
 	CreateActivity(activity *Activity) (string, error)
 }
@@ -33,6 +34,10 @@ func (svc *Service) GetActivity(id int) (string, error) {
 func (svc *Service) CreateActivity(activity *Activity) (string, error) {
 	fmt.Println(*activity)
 	return "Created activity", nil
+}
+
+func (svc *Service) GetActivities() []Activity {
+	return []Activity{}
 }
 
 func NewService() ActivityService {

--- a/internal/activities/service.go
+++ b/internal/activities/service.go
@@ -1,10 +1,12 @@
 package activities
 
+import "fmt"
+
 // the Activity Model
 type Activity struct {
 	id    int
 	count int
-	title string
+	Title string `json:"title"`
 }
 
 // the Activity DB Layer
@@ -16,6 +18,7 @@ type Activity struct {
 // the Activity Service interface
 type ActivityService interface {
 	GetActivity(id int) (string, error)
+	CreateActivity(activity *Activity) (string, error)
 }
 
 // the Service struct
@@ -24,7 +27,12 @@ type Service struct{}
 // Take data from handler and call create an Activity
 // Take data from handler and call read an Activity
 func (svc *Service) GetActivity(id int) (string, error) {
-	return "Hello", nil
+	return "Got activity", nil
+}
+
+func (svc *Service) CreateActivity(activity *Activity) (string, error) {
+	fmt.Println(*activity)
+	return "Created activity", nil
 }
 
 func NewService() ActivityService {

--- a/internal/activities/service.go
+++ b/internal/activities/service.go
@@ -1,0 +1,35 @@
+package activities
+
+// the Activity Model
+type Activity struct {
+	id    int
+	count int
+	title string
+}
+
+// the Activity DB Layer
+// Create an Activity
+// Read an Activity
+// Update an Activity
+// Delete an Activity
+
+// the Activity Service interface
+type ActivityService interface {
+	GetActivity(id int) (string, error)
+}
+
+// the Service struct
+type Service struct{}
+
+// Take data from handler and call create an Activity
+// Take data from handler and call read an Activity
+func (svc *Service) GetActivity(id int) (string, error) {
+	return "Hello", nil
+}
+
+func NewService() ActivityService {
+	return &Service{}
+}
+
+// Take data from handler and call update an Activity
+// Take data from handler and call delete an Activity


### PR DESCRIPTION
We want to ensure that there are clear separation of concerns moving forward:
1. A handler layer (for HTTP responses)
2. A service layer (for business logic)

Currently, I put the type struct and the service in one place. In the future, when integrating with a DB, need a separate layer for DB operations as well as a centralised place to put the type struct.